### PR TITLE
removed GO15VENDOREXPERIMENT=1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ TARGETS_NOVENDOR=$(shell glide novendor)
 all: wbt
 
 wbt: cmd/wbt/*.go server/*.go jsonrpc/*.go config/*.go wlog/*.go *.go
-	GO15VENDOREXPERIMENT=1 go build cmd/wbt/wbt.go
+	go build cmd/wbt/wbt.go
 
 bundle:
 	glide install
 
 check:
-	GO15VENDOREXPERIMENT=1 go test $(TARGETS_NOVENDOR)
+	go test $(TARGETS_NOVENDOR)
 
 fmt:
 	@echo $(TARGETS_NOVENDOR) | xargs go fmt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Widebullet is RESTful API gateway with JSON-RPC.
 
 Production ready.
 
+## Requirements
+
+Gaurun requires Go1.7.3 or later.
+
 # Installation
 
 ```


### PR DESCRIPTION
After merge #3, widebullet requires Go1.7 or later.