### PR TITLE
Proxy: enabled HTTPS endpoint.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,4 +25,22 @@ A configuration for Widebullet has some sections. A example is [here](config/exa
 |Ep             |string        |Endpoint URL                       |       |    |
 |ProxySetHeaders|array of array|Headers appended on proxing request|       |    |
 
+As a scheme, **http** and **https** are available for **Ep**.
+
+```
+Ep = "http://example.com"
+# or
+Ep = "https://example.com"
+```
+
+If a scheme is not specified, **http** is used.
+
+```
+Ep = "example.com"
+```
+
+* example.com
+
+# About API
+
 See [SPEC.md](SPEC.md) about details for APIs.

--- a/server/builder.go
+++ b/server/builder.go
@@ -16,6 +16,9 @@ func buildRequestURI(ep, method, qs string) string {
 	if len(ep) > 7 && ep[:7] == "http://" {
 		return fmt.Sprintf("%s%s%s", ep, method, qs)
 	}
+	if len(ep) > 8 && ep[:8] == "https://" {
+		return fmt.Sprintf("%s%s%s", ep, method, qs)
+	}
 	return fmt.Sprintf("http://%s%s%s", ep, method, qs)
 }
 


### PR DESCRIPTION
As a scheme, **http** and **https** are available for **Ep**.

```
Ep = "http://example.com"
# or
Ep = "https://example.com"
```

If a scheme is not specified, **http** is used.

```                                                                                                                                                                                                               
Ep = "example.com"                                                                                                                                                                                                
```
