### PR TITLE
Support hot-deploying (with graceful shutdown)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Production ready.
 
 # Requirement
 
-Widebullet requires Go1.7.3 or later.
+Widebullet requires Go1.8 or later.
 
 # Installation
 

--- a/cmd/wbt/wbt.go
+++ b/cmd/wbt/wbt.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/mercari/widebullet"
 	"github.com/mercari/widebullet/config"
@@ -36,6 +42,36 @@ func main() {
 	wbt.AL = wlog.AccessLogger(conf.LogLevel)
 	wbt.EL = wlog.ErrorLogger(conf.LogLevel)
 
-	server.RegisterHandlers()
-	server.Run()
+	// Setup server
+	mux := http.NewServeMux()
+	server.RegisterHandlers(mux)
+	server.SetupClient(&wbt.Config)
+
+	srv := &http.Server{
+		Handler: mux,
+	}
+
+	go func() {
+		wbt.EL.Out(wlog.Debug, "Start running server")
+		if err := server.Run(srv, &wbt.Config); err != nil {
+			wbt.EL.Out(wlog.Error, "Failed to run server: %s", err)
+		}
+	}()
+
+	// Watch SIGTERM signal and then gracefully shutdown
+	sigCh := make(chan os.Signal)
+	signal.Notify(sigCh, syscall.SIGTERM)
+	<-sigCh
+
+	wbt.EL.Out(wlog.Debug, "Start to shutdown server")
+	timeout := time.Duration(conf.ShutdownTimeout) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		wbt.EL.Out(wlog.Error, "Failed to shutdown server: %s", err)
+		return
+	}
+
+	wbt.EL.Out(wlog.Debug, "Successfully shutdown server")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ const (
 	DefaultMaxIdleConnsPerHost = 100
 	DefaultIdleConnTimeout     = 30
 	DefaultProxyReadTimeout    = 60
+	DefaultShutdownTimeout     = 10
 )
 
 type Config struct {
@@ -25,6 +26,7 @@ type Config struct {
 	DisableCompression  bool
 	IdleConnTimeout     int
 	ProxyReadTimeout    int
+	ShutdownTimeout     int
 	Endpoints           []EndPoint
 }
 
@@ -75,6 +77,10 @@ func Load(confPath string) (Config, error) {
 
 	if config.ProxyReadTimeout <= 0 {
 		config.ProxyReadTimeout = DefaultProxyReadTimeout
+	}
+
+	if config.ShutdownTimeout <= 0 {
+		config.ShutdownTimeout = DefaultShutdownTimeout
 	}
 
 	if len(config.Endpoints) == 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@ func TestLoadExampleToml(t *testing.T) {
 	assert.Equal(false, c.DisableCompression)
 	assert.Equal(30, c.IdleConnTimeout)
 	assert.Equal(60, c.ProxyReadTimeout)
+	assert.Equal(15, c.ShutdownTimeout)
 
 	eps := c.Endpoints
 	assert.Equal(2, len(eps))

--- a/config/example.toml
+++ b/config/example.toml
@@ -5,6 +5,7 @@ MaxIdleConnsPerHost = 100
 DisableCompression = false
 IdleConnTimeout = 30
 ProxyReadTimeout = 60
+ShutdownTimeout = 15
 
 [[Endpoints]]
 Name = "ep-1"


### PR DESCRIPTION
For hot-deploying, support `lestrrat/go-server-starter` listeners. 

Graceful shutdown is done by Go1.8's graceful shutdown feature (see [release note](https://tip.golang.org/doc/go1.8#http_shutdown)). So this PR must be merged after go1.8 release. 

## Test

To test hot-deploying feature, run `wbt` by `server-starter` and kill HUP to it constantly (per sec.) and send 1000 requests to check there is no lost requests. 

To kick `wbt`,

```bash
$ start_server --port 8080 --pid-file=/tmp/test.pid -- wbt -c config/example.toml
```

To constantly kill HUP it,

```bash
$ while true; do kill -HUP $(cat /tmp/test.pid); sleep 1s; done
```

Requests are done by [`hey`]() command,

```bash
$ hey -n 1000 -c 100 -D test.json -m POST 'http://localhost:8080/wbt'
```

The results are the followings. Sometimes requests takes long time (but very small number) but no requests are lost.

```bash
Summary:
  Total:        25.3181 secs
  Slowest:      19.4102 secs
  Fastest:      0.0004 secs
  Average:      1.6511 secs
  Requests/sec: 39.4974
  Total data:   564877 bytes
  Size/request: 564 bytes

Status code distribution:
  [200] 1000 responses

Response time histogram:
  0.000 [1]     |
  1.941 [623]   |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  3.882 [259]   |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  5.823 [86]    |∎∎∎∎∎∎
  7.764 [6]     |
  9.705 [0]     |
  11.646 [0]    |
  13.587 [0]    |
  15.528 [0]    |
  17.469 [0]    |
  19.410 [25]   |∎∎

Latency distribution:
  10% in 0.0029 secs
  25% in 0.0049 secs
  50% in 0.0309 secs
  75% in 1.9808 secs
  90% in 5.0027 secs
  95% in 5.0092 secs
  99% in 19.4014 secs
```

