### PR TITLE
enabled to pass header values to request headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,10 @@ type Config struct {
 }
 
 type EndPoint struct {
-	Name            string
-	Ep              string
-	ProxySetHeaders [][]string
+	Name             string
+	Ep               string
+	ProxySetHeaders  [][]string
+	ProxyPassHeaders [][]string
 }
 
 func LoadBytes(bytes []byte) (Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,6 +62,8 @@ func TestFindEp(t *testing.T) {
 	assert.Equal("127.0.0.1:30001", ep.Ep)
 	assert.Equal("Host", ep.ProxySetHeaders[0][0])
 	assert.Equal("ep1.example.com", ep.ProxySetHeaders[0][1])
+	assert.Equal("Authorization", ep.ProxyPassHeaders[0][0])
+	assert.Equal("X-Auth-Token", ep.ProxyPassHeaders[0][1])
 
 	ep, err = FindEp(c, "ep-2")
 	assert.Nil(err)
@@ -69,6 +71,8 @@ func TestFindEp(t *testing.T) {
 	assert.Equal("http://127.0.0.1:30002", ep.Ep)
 	assert.Equal("Host", ep.ProxySetHeaders[0][0])
 	assert.Equal("ep2.example.com", ep.ProxySetHeaders[0][1])
+	assert.Equal("Authorization", ep.ProxyPassHeaders[0][0])
+	assert.Equal("X-Auth-Token2", ep.ProxyPassHeaders[0][1])
 
 	_, err = FindEp(c, "ep-3")
 	assert.NotNil(err)

--- a/config/example.toml
+++ b/config/example.toml
@@ -13,10 +13,16 @@ Ep = "127.0.0.1:30001"
 ProxySetHeaders = [
     ["Host", "ep1.example.com"],
 ]
+ProxyPassHeaders = [
+    ["Authorization", "X-Auth-Token"]
+]
 
 [[Endpoints]]
 Name = "ep-2"
 Ep = "http://127.0.0.1:30002"
 ProxySetHeaders = [
     ["Host", "ep2.example.com"],
+]
+ProxyPassHeaders = [
+    ["Authorization", "X-Auth-Token2"]
 ]

--- a/server/builder.go
+++ b/server/builder.go
@@ -127,5 +127,24 @@ func buildHttpRequest(reqj *jsonrpc.Request, forwardHeaders *http.Header) (*http
 		}
 	}
 
+	for _, passHeaders := range ep.ProxyPassHeaders {
+		length := len(passHeaders)
+		if length < 2 {
+			continue
+		}
+		key := passHeaders[0]
+		realIndex := 0
+		passedValues := make([]string, length)
+		for _, headerKey := range passHeaders[1:] {
+			headerValue := forwardHeaders.Get(headerKey)
+			if len(headerValue) > 0 {
+				passedValues[realIndex] = headerValue
+				realIndex++
+			}
+		}
+		value := strings.Join(passedValues[:realIndex], ",")
+		reqh.Header.Set(key, value)
+	}
+
 	return reqh, nil
 }

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -47,6 +47,8 @@ func TestBuildHttpRequest(t *testing.T) {
 
 	headers := make(http.Header)
 	headers.Add("X-Forwarded-For", "127.0.0.1")
+	headers.Add("X-Auth-Token", "Bearer test_token")
+	headers.Add("X-Auth-Token2", "Bearer another_testtoken")
 	for _, reqj := range reqjs {
 		reqh, err := buildHttpRequest(&reqj, &headers)
 		assert.Nil(err)
@@ -60,12 +62,14 @@ func TestBuildHttpRequest(t *testing.T) {
 	assert.Equal("127.0.0.1:30001", reqhs[0].URL.Host)
 	assert.Equal("/user/get", reqhs[0].URL.Path)
 	assert.Equal("user_id=1", reqhs[0].URL.RawQuery)
+	assert.Equal("Bearer test_token", reqhs[0].Header.Get("Authorization"))
 
 	assert.Equal("", reqhs[1].Header.Get("Content-Type"))
 	assert.Equal("ep1.example.com", reqhs[1].Host)
 	assert.Equal("127.0.0.1:30001", reqhs[1].URL.Host)
 	assert.Equal("/item/get", reqhs[1].URL.Path)
 	assert.Equal("item_id=2", reqhs[1].URL.RawQuery)
+	assert.Equal("Bearer test_token", reqhs[1].Header.Get("Authorization"))
 
 	buf.ReadFrom(reqhs[2].Body)
 	assert.Equal("application/x-www-form-urlencoded", reqhs[2].Header.Get("Content-Type"))
@@ -73,4 +77,5 @@ func TestBuildHttpRequest(t *testing.T) {
 	assert.Equal("127.0.0.1:30002", reqhs[2].URL.Host)
 	assert.Equal("/item/update", reqhs[2].URL.Path)
 	assert.Equal("desc=update&item_id=2", buf.String())
+	assert.Equal("Bearer another_testtoken", reqhs[2].Header.Get("Authorization"))
 }


### PR DESCRIPTION
i want set some values to request headers from a request to widebullet server.
thought to use  when call some apis to use different tokens to authorize.

i added "ProxyPassHeaders" settings to config, and part using that.
sorry to bother you, please indicate how work if there are any solutions to do that.

thank you.


