### PR TITLE
Added error message into JSON-RPC response when the status code is not 2xx

### DIFF
--- a/server/builder.go
+++ b/server/builder.go
@@ -65,12 +65,26 @@ func buildJsonRpcErrorResponse(code int, msg, id string, time float64) jsonrpc.R
 	}
 }
 
-func buildHttpError2JsonRpcErrorResponse(resp *http.Response, id string, time float64) jsonrpc.Response {
-	switch resp.StatusCode {
-	case http.StatusNotFound:
-		return buildJsonRpcErrorResponse(jsonrpc.MethodNotFoundError, resp.Status, id, time)
+func buildHttpError2JsonRpcErrorResponse(status_code int, err_msg string, id string, time float64) jsonrpc.Response {
+
+	r := &struct {
+		StatusCode int    `json:"status_code"`
+		Message    string `json:"message"`
+	} {
+		status_code,
+		err_msg,
 	}
-	return buildJsonRpcErrorResponse(jsonrpc.InternalError, resp.Status, id, time)
+
+	jsonrpc_err_msg, err := json.Marshal(r)
+	if err != nil {
+		return buildJsonRpcErrorResponse(jsonrpc.InternalError, err.Error(), id, time)
+	}
+
+	switch status_code {
+	case http.StatusNotFound:
+		return buildJsonRpcErrorResponse(jsonrpc.MethodNotFoundError, string(jsonrpc_err_msg), id, time)
+	}
+	return buildJsonRpcErrorResponse(jsonrpc.InternalError, string(jsonrpc_err_msg), id, time)
 }
 
 func buildHttpRequest(reqj *jsonrpc.Request, forwardHeaders *http.Header) (*http.Request, error) {

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -27,18 +27,21 @@ func sendHttpRequest(wg *sync.WaitGroup, reqj jsonrpc.Request, forwardHeaders *h
 		errorLog(wlog.Error, err.Error())
 		return
 	}
+
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		*respj = buildHttpError2JsonRpcErrorResponse(resp, reqj.ID, ptime)
-		errorLog(wlog.Error, "%#v is failed: %s", reqj, resp.Status)
-		return
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		*respj = buildJsonRpcErrorResponse(jsonrpc.InternalError, err.Error(), reqj.ID, ptime)
 		errorLog(wlog.Error, err.Error())
 		return
 	}
+
+	if resp.StatusCode != 200 {
+		*respj = buildHttpError2JsonRpcErrorResponse(resp.StatusCode, string(body), reqj.ID, ptime)
+		errorLog(wlog.Error, "%#v is failed: %s", reqj, resp.Status)
+		return
+	}
+
 	*respj = buildJsonRpcResponse(string(body), reqj.ID, ptime)
 }
 


### PR DESCRIPTION
Added changes to return the error message to widebullet client when the HTTP status code is not 2xx.
Clients can use them for error handling.

thanks.
